### PR TITLE
Update dependencies (2026-04)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.11",
+    "@biomejs/biome": "2.4.12",
     "tsup": "^8.3.5",
     "typedoc": "^0.28.18",
     "typedoc-plugin-markdown": "^4.11.0",


### PR DESCRIPTION
## Language runtime

- Node.js: kept at major version `24` in `.github/actions/install/action.yml` (still the latest active LTS, "Krypton").

## Package manager

- pnpm: kept at `10.33.0` (no newer release).

## Individual packages

- `@biomejs/biome`: `2.4.11` -> `2.4.12` (patch release: new lint rules, diagnostic improvements, no breaking changes).

## Bulk updates

- None.

## Skipped

- `tsup` (`^8.3.5`): caret range already accepts the latest `8.5.1`; no minimum bump needed.
- `typedoc` (`^0.28.18`): caret range already accepts the latest `0.28.19`.
- `typedoc-plugin-markdown` (`^4.11.0`): already at the latest version.
- `typedoc-plugin-missing-exports` (`^4.1.3`): already at the latest version.
- `typescript` (`^6.0.2`): caret range already accepts the latest `6.0.3`.
- `valibot` (`^1.3.1`): already at the latest version.
- `vitest` (`^4.1.4`): already at the latest version.

## Notes

- `pnpm-lock.yaml` was not regenerated because the MCP environment cannot run `pnpm install`. Please run `pnpm install` locally to refresh the lockfile before merging.
